### PR TITLE
Add CoreText renderer plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(dpFontBaker)
 
+option(DPFB_USE_CORETEXT "Include CoreText renderer" OFF)
 option(DPFB_USE_FREETYPE "Include FreeType renderer" ON)
 option(DPFB_USE_STBTT "Include stb_truetype.h renderer" ON)
 option(DPFB_USE_LIBPNG "Enable PNG support" ON)
@@ -16,6 +17,7 @@ add_executable(
     src/font_renderer/font_renderer.cpp
     src/font_renderer/ft_font_renderer.cpp
     src/font_renderer/stb_font_renderer.cpp
+    src/font_renderer/ct_font_renderer.cpp
     src/font_writer/bmfont_writer.cpp
     src/font_writer/font_writer.cpp
     src/font_writer/json_font_writer.cpp
@@ -52,6 +54,7 @@ endif()
 target_compile_definitions(
     dpfb
     PRIVATE
+    DPFB_USE_CORETEXT=$<BOOL:${DPFB_USE_CORETEXT}>
     DPFB_USE_FREETYPE=$<BOOL:${DPFB_USE_FREETYPE}>
     DPFB_USE_STBTT=$<BOOL:${DPFB_USE_STBTT}>
     DPFB_USE_LIBPNG=$<BOOL:${DPFB_USE_LIBPNG}>
@@ -86,6 +89,12 @@ if (DPFB_USE_LIBPNG)
     find_package(PNG REQUIRED)
     target_include_directories(dpfb PRIVATE ${PNG_INCLUDE_DIRS})
     target_link_libraries(dpfb ${PNG_LIBRARIES})
+endif()
+
+if (DPFB_USE_CORETEXT)
+    target_link_libraries(dpfb "-framework CoreText")
+    target_link_libraries(dpfb "-framework CoreGraphics")
+    target_link_libraries(dpfb "-framework CoreFoundation")
 endif()
 
 if (DPFB_BUILD_TESTS)

--- a/src/external/dp_rect_pack.h
+++ b/src/external/dp_rect_pack.h
@@ -274,7 +274,7 @@ private:
         {}
     };
 
-    class Context;
+    struct Context;
     class Page {
     public:
         Page()

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -15,6 +15,7 @@
 
 
 using namespace streams;
+using namespace Geometry;
 
 
 static std::vector<std::uint8_t> getData(const std::string& fileName)

--- a/src/font.h
+++ b/src/font.h
@@ -29,10 +29,10 @@ struct FontBakingOptions {
     int fontPxSize;
     Hinting hinting;
     int imageMaxSize;
-    Edge imagePadding;
-    Edge glyphPaddingInner;
-    Edge glyphPaddingOuter;
-    Point glyphSpacing;
+    Geometry::Edge imagePadding;
+    Geometry::Edge glyphPaddingInner;
+    Geometry::Edge glyphPaddingOuter;
+    Geometry::Point glyphSpacing;
     KerningSource kerningSource;
 };
 
@@ -69,7 +69,7 @@ struct StyleFlags {
 
 
 struct Page {
-    Size size;
+    Geometry::Size size;
     std::vector<std::uint_least32_t> glyphIndices;
 };
 
@@ -77,11 +77,11 @@ struct Page {
 struct Glyph {
     char32_t cp;
     GlyphIndex glyphIdx;
-    Size size;
-    Point drawOffset;
+    Geometry::Size size;
+    Geometry::Point drawOffset;
     int advance;
     std::uint_least32_t pageIdx;
-    Point pagePos;
+    Geometry::Point pagePos;
 };
 
 

--- a/src/font_renderer/ct_font_renderer.cpp
+++ b/src/font_renderer/ct_font_renderer.cpp
@@ -1,0 +1,140 @@
+
+#if DPFB_USE_CORETEXT
+
+#include "font_renderer/font_renderer.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <CoreText/CoreText.h>
+
+
+
+class CtFontRenderer : public FontRenderer {
+public:
+    explicit CtFontRenderer(const FontRendererArgs& args);
+
+    FontMetrics getFontMetrics() const override;
+
+    GlyphIndex getGlyphIndex(char32_t cp) const override;
+    GlyphMetrics getGlyphMetrics(GlyphIndex glyphIdx) const override;
+    void renderGlyph(GlyphIndex glyphIdx, Image& image) const override;
+    virtual ~CtFontRenderer() override;
+private:
+    CTFontRef font;
+};
+
+
+CtFontRenderer::CtFontRenderer(const FontRendererArgs& args)
+{
+    CFStringRef fontName = CFStringCreateWithCString(NULL, (const char*)args.data, kCFStringEncodingUTF8);
+    font = CTFontCreateWithName(fontName, args.pxSize, NULL);
+    CFRelease(fontName);
+    if (!font)
+        throw FontRendererError("CoreText can't init font");
+}
+
+
+FontMetrics CtFontRenderer::getFontMetrics() const
+{
+    FontMetrics metrics;
+
+    metrics.ascender = ceil(CTFontGetAscent(font));
+    metrics.descender = ceil(CTFontGetDescent(font));
+    metrics.lineHeight = ceil(CTFontGetLeading(font) + CTFontGetAscent(font) + CTFontGetDescent(font));
+
+    return metrics;
+}
+
+
+GlyphIndex CtFontRenderer::getGlyphIndex(char32_t cp) const
+{
+    CGGlyph glyph;
+    UniChar ch = (UniChar)cp;
+    if (CTFontGetGlyphsForCharacters(font, &ch, &glyph, 1))
+        return (GlyphIndex)glyph;
+    return 0;
+}
+
+#define CORETEXT_SHIFT_X_POSITION 1
+
+GlyphMetrics CtFontRenderer::getGlyphMetrics(GlyphIndex glyphIdx) const
+{
+    GlyphMetrics glyphMetrics;
+    CGGlyph glyph = (CGGlyph)glyphIdx;
+
+    CGSize advance;
+    CTFontGetAdvancesForGlyphs(font, kCTFontOrientationDefault, &glyph, &advance, 1);
+    glyphMetrics.advance = round(advance.width);
+
+    CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, &glyph, NULL, 1);
+#if CORETEXT_SHIFT_X_POSITION
+    glyphMetrics.size.w = ceil(boundingRect.size.width) + ceil(boundingRect.origin.x);
+#else
+    glyphMetrics.size.w = ceil(boundingRect.size.width);
+#endif
+    glyphMetrics.offset.x = ceil(boundingRect.origin.x);
+
+    glyphMetrics.size.h = ceil(boundingRect.size.height);
+    glyphMetrics.offset.y = ceil(boundingRect.size.height) + ceil(boundingRect.origin.y);
+
+    return glyphMetrics;
+}
+
+
+void CtFontRenderer::renderGlyph(GlyphIndex glyphIdx, Image& image) const
+{
+    if (image.getWidth() == 0 || image.getHeight() == 0)
+        return;
+
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceGray();
+    CGContextRef context = CGBitmapContextCreate(image.getData(), image.getWidth(), image.getHeight(),
+                                                 8, image.getPitch(), colorSpace, kCGImageAlphaOnly);
+
+    CGFontRef cgFont = CTFontCopyGraphicsFont(font, NULL);
+    CGContextSetFont(context, cgFont);
+    CGContextSetFontSize(context, CTFontGetSize(font));
+    CGContextSetFillColorWithColor(context, CGColorGetConstantColor(kCGColorWhite));
+    CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, (const CGGlyph*)&glyphIdx, NULL, 1);
+    CGPoint position = boundingRect.origin;
+#if CORETEXT_SHIFT_X_POSITION
+    position.x = 0;
+#else
+    position.x = -position.x;
+#endif
+    position.y = -position.y;
+    CGContextShowGlyphsAtPositions(context, (const CGGlyph*)&glyphIdx, &position, 1);
+    CGContextFlush(context);
+    CGContextRelease(context);
+    CFRelease(cgFont);
+    CGColorSpaceRelease(colorSpace);
+}
+
+CtFontRenderer::~CtFontRenderer()
+{
+    CFRelease(font);
+}
+
+
+class CtFontRendererCreator : public FontRendererCreator {
+public:
+    CtFontRendererCreator()
+        : FontRendererCreator("ct")
+    {
+    }
+
+    const char* getDescription() const override
+    {
+        return "CoreText";
+    }
+
+    FontRenderer* create(const FontRendererArgs& args) const override
+    {
+        return new CtFontRenderer(args);
+    }
+};
+
+
+static CtFontRendererCreator creatorInstance;
+
+
+#endif  // DPFB_USE_CORETEXT

--- a/src/font_renderer/ct_font_renderer.cpp
+++ b/src/font_renderer/ct_font_renderer.cpp
@@ -57,8 +57,6 @@ GlyphIndex CtFontRenderer::getGlyphIndex(char32_t cp) const
     return 0;
 }
 
-#define CORETEXT_SHIFT_X_POSITION 1
-
 GlyphMetrics CtFontRenderer::getGlyphMetrics(GlyphIndex glyphIdx) const
 {
     GlyphMetrics glyphMetrics;
@@ -69,13 +67,8 @@ GlyphMetrics CtFontRenderer::getGlyphMetrics(GlyphIndex glyphIdx) const
     glyphMetrics.advance = round(advance.width);
 
     CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, &glyph, nullptr, 1);
-#if CORETEXT_SHIFT_X_POSITION
     glyphMetrics.size.w = ceil(boundingRect.size.width) + ceil(boundingRect.origin.x);
     glyphMetrics.offset.x = 0;
-#else
-    glyphMetrics.size.w = ceil(boundingRect.size.width);
-    glyphMetrics.offset.x = ceil(boundingRect.origin.x);
-#endif
 
     glyphMetrics.size.h = ceil(boundingRect.size.height);
     glyphMetrics.offset.y = ceil(boundingRect.size.height) + ceil(boundingRect.origin.y);
@@ -100,11 +93,7 @@ void CtFontRenderer::renderGlyph(GlyphIndex glyphIdx, Image& image) const
     CGContextSetFillColorWithColor(context, CGColorGetConstantColor(kCGColorWhite));
     CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, &glyph, nullptr, 1);
     CGPoint position = boundingRect.origin;
-#if CORETEXT_SHIFT_X_POSITION
     position.x = 0;
-#else
-    position.x = -position.x;
-#endif
     position.y = -position.y;
     CGContextShowGlyphsAtPositions(context, &glyph, &position, 1);
     CGContextFlush(context);

--- a/src/font_renderer/ct_font_renderer.cpp
+++ b/src/font_renderer/ct_font_renderer.cpp
@@ -49,9 +49,9 @@ FontMetrics CtFontRenderer::getFontMetrics() const
 GlyphIndex CtFontRenderer::getGlyphIndex(char32_t cp) const
 {
     CGGlyph glyph;
-    UniChar ch = (UniChar)cp;
+    UniChar ch = static_cast<UniChar>(cp);
     if (CTFontGetGlyphsForCharacters(font, &ch, &glyph, 1))
-        return (GlyphIndex)glyph;
+        return static_cast<GlyphIndex>(glyph);
     return 0;
 }
 
@@ -60,13 +60,13 @@ GlyphIndex CtFontRenderer::getGlyphIndex(char32_t cp) const
 GlyphMetrics CtFontRenderer::getGlyphMetrics(GlyphIndex glyphIdx) const
 {
     GlyphMetrics glyphMetrics;
-    CGGlyph glyph = (CGGlyph)glyphIdx;
+    CGGlyph glyph = static_cast<CGGlyph>(glyphIdx);
 
     CGSize advance;
     CTFontGetAdvancesForGlyphs(font, kCTFontOrientationDefault, &glyph, &advance, 1);
     glyphMetrics.advance = round(advance.width);
 
-    CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, &glyph, NULL, 1);
+    CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, &glyph, nullptr, 1);
 #if CORETEXT_SHIFT_X_POSITION
     glyphMetrics.size.w = ceil(boundingRect.size.width) + ceil(boundingRect.origin.x);
     glyphMetrics.offset.x = 0;
@@ -84,6 +84,7 @@ GlyphMetrics CtFontRenderer::getGlyphMetrics(GlyphIndex glyphIdx) const
 
 void CtFontRenderer::renderGlyph(GlyphIndex glyphIdx, Image& image) const
 {
+    CGGlyph glyph = static_cast<CGGlyph>(glyphIdx);
     if (image.getWidth() == 0 || image.getHeight() == 0)
         return;
 
@@ -91,11 +92,11 @@ void CtFontRenderer::renderGlyph(GlyphIndex glyphIdx, Image& image) const
     CGContextRef context = CGBitmapContextCreate(image.getData(), image.getWidth(), image.getHeight(),
                                                  8, image.getPitch(), colorSpace, kCGImageAlphaOnly);
 
-    CGFontRef cgFont = CTFontCopyGraphicsFont(font, NULL);
+    CGFontRef cgFont = CTFontCopyGraphicsFont(font, nullptr);
     CGContextSetFont(context, cgFont);
     CGContextSetFontSize(context, CTFontGetSize(font));
     CGContextSetFillColorWithColor(context, CGColorGetConstantColor(kCGColorWhite));
-    CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, (const CGGlyph*)&glyphIdx, NULL, 1);
+    CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, &glyph, nullptr, 1);
     CGPoint position = boundingRect.origin;
 #if CORETEXT_SHIFT_X_POSITION
     position.x = 0;
@@ -103,7 +104,7 @@ void CtFontRenderer::renderGlyph(GlyphIndex glyphIdx, Image& image) const
     position.x = -position.x;
 #endif
     position.y = -position.y;
-    CGContextShowGlyphsAtPositions(context, (const CGGlyph*)&glyphIdx, &position, 1);
+    CGContextShowGlyphsAtPositions(context, &glyph, &position, 1);
     CGContextFlush(context);
     CGContextRelease(context);
     CFRelease(cgFont);

--- a/src/font_renderer/ct_font_renderer.cpp
+++ b/src/font_renderer/ct_font_renderer.cpp
@@ -26,9 +26,11 @@ private:
 
 CtFontRenderer::CtFontRenderer(const FontRendererArgs& args)
 {
-    CFStringRef fontName = CFStringCreateWithCString(NULL, (const char*)args.data, kCFStringEncodingUTF8);
-    font = CTFontCreateWithName(fontName, args.pxSize, NULL);
-    CFRelease(fontName);
+    CTFontDescriptorRef descriptor = CTFontManagerCreateFontDescriptorFromData(CFDataCreate(nullptr, static_cast<const UInt8*>(args.data), args.dataSize));
+    if (!descriptor)
+        throw FontRendererError("CoreText can't create descriptor");
+    font = CTFontCreateWithFontDescriptor(descriptor, static_cast<CGFloat>(args.pxSize), nullptr);
+    CFRelease(descriptor);
     if (!font)
         throw FontRendererError("CoreText can't init font");
 }

--- a/src/font_renderer/ct_font_renderer.cpp
+++ b/src/font_renderer/ct_font_renderer.cpp
@@ -69,10 +69,11 @@ GlyphMetrics CtFontRenderer::getGlyphMetrics(GlyphIndex glyphIdx) const
     CGRect boundingRect = CTFontGetBoundingRectsForGlyphs(font, kCTFontOrientationDefault, &glyph, NULL, 1);
 #if CORETEXT_SHIFT_X_POSITION
     glyphMetrics.size.w = ceil(boundingRect.size.width) + ceil(boundingRect.origin.x);
+    glyphMetrics.offset.x = 0;
 #else
     glyphMetrics.size.w = ceil(boundingRect.size.width);
-#endif
     glyphMetrics.offset.x = ceil(boundingRect.origin.x);
+#endif
 
     glyphMetrics.size.h = ceil(boundingRect.size.height);
     glyphMetrics.offset.y = ceil(boundingRect.size.height) + ceil(boundingRect.origin.y);

--- a/src/font_renderer/font_renderer.h
+++ b/src/font_renderer/font_renderer.h
@@ -36,7 +36,7 @@ struct GlyphMetrics {
     /**
      * Size of the glyph's bitmap.
      */
-    Size size;
+    Geometry::Size size;
 
     /**
      * Offset from the origin.
@@ -45,7 +45,7 @@ struct GlyphMetrics {
      * from the origin on the baseline. Like in FreeType, the y
      * coordinate increases up.
      */
-    Point offset;
+    Geometry::Point offset;
 
     /**
      * X advance.

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -1,63 +1,65 @@
 
 #pragma once
 
+namespace Geometry
+{
+    struct Point {
+        int x;
+        int y;
 
-struct Point {
-    int x;
-    int y;
+        Point()
+            : Point(0, 0)
+        {
 
-    Point()
-        : Point(0, 0)
-    {
+        }
 
-    }
+        Point(int x, int y)
+            : x {x}
+            , y {y}
+        {
 
-    Point(int x, int y)
-        : x {x}
-        , y {y}
-    {
-
-    }
-};
-
-
-struct Size {
-    int w;
-    int h;
-
-    Size()
-        : Size(0, 0)
-    {
-
-    }
-
-    Size(int w, int h)
-        : w {w}
-        , h {h}
-    {
-
-    }
-};
+        }
+    };
 
 
-struct Edge {
-    int top;
-    int bottom;
-    int left;
-    int right;
+    struct Size {
+        int w;
+        int h;
 
-    explicit Edge(int edge = 0)
-        : Edge(edge, edge, edge, edge)
-    {
+        Size()
+            : Size(0, 0)
+        {
 
-    }
+        }
 
-    Edge(int top, int bottom, int left, int right)
-        : top(top)
-        , bottom(bottom)
-        , left(left)
-        , right(right)
-    {
+        Size(int w, int h)
+            : w {w}
+            , h {h}
+        {
 
-    }
-};
+        }
+    };
+
+
+    struct Edge {
+        int top;
+        int bottom;
+        int left;
+        int right;
+
+        explicit Edge(int edge = 0)
+            : Edge(edge, edge, edge, edge)
+        {
+
+        }
+
+        Edge(int top, int bottom, int left, int right)
+            : top(top)
+            , bottom(bottom)
+            , left(left)
+            , right(right)
+        {
+
+        }
+    };
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "streams/file_stream.h"
 #include "unicode.h"
 
+using namespace Geometry;
 
 const char* const dirSeparators = (
     #ifdef _WIN32


### PR DESCRIPTION
Uses native rendering engine on macOS. 

I had to move `Size` and `Point` into `Geometry` namespace, because `Size` and `Point` are already defined in `/usr/include/MacTypes.h` which is included from `CoreFoundation.h`.